### PR TITLE
fix: bug when sending payload/data type of bytes instead of strings

### DIFF
--- a/winpwn/misc.py
+++ b/winpwn/misc.py
@@ -137,7 +137,13 @@ def showbuf(buf,is_noout=None):
     if not is_noout:
         if context.log_level=='debug':
             hexdump(buf)
-        if buf.endswith(context.newline):
-            os.write(sys.stdout.fileno(), Latin1_encode(buf))
+        if type(buf)==str:
+            if buf.endswith(context.newline if type(context.newline)==str else context.newline.decode()):
+                os.write(sys.stdout.fileno(), Latin1_encode(buf))
+            else:
+                os.write(sys.stdout.fileno(), Latin1_encode(buf+'\n'))
         else:
-            os.write(sys.stdout.fileno(), Latin1_encode(buf+'\n'))
+            if buf.endswith(context.newline if type(context.newline)==bytes else context.newline.encode()):
+                os.write(sys.stdout.fileno(), buf)
+            else:
+                os.write(sys.stdout.fileno(), buf+b'\n')

--- a/winpwn/win.py
+++ b/winpwn/win.py
@@ -154,7 +154,7 @@ class winPipe():
         return Latin1_decode(buf.raw)
 
     def write(self,buf=''):
-        buf=Latin1_encode(buf)
+        buf=Latin1_encode(buf) if type(buf)==str else buf
         length=len(buf)
         written=wintypes.DWORD()
         x=windll.kernel32.WriteFile(self.hWritePipe,buf,length,byref(written),None)

--- a/winpwn/winpwn.py
+++ b/winpwn/winpwn.py
@@ -154,7 +154,7 @@ class remote(tube):
         self.sock.settimeout(self.timeout)
         return Latin1_decode(buf)
     def write(self,buf):
-        return self.sock.send(Latin1_encode(buf))
+        return self.sock.send(Latin1_encode(buf) if type(buf)==str else buf)
     def close(self):
         self.sock.close()
         self._is_exit=True

--- a/winpwn/winpwn.py
+++ b/winpwn/winpwn.py
@@ -37,6 +37,10 @@ class tube(object):
     def sendline(self,buf,newline=None):
         if newline is None:
             newline=context.newline
+        if isinstance(buf,str) and isinstance(newline,str):
+            buf=Latin1_encode(buf)
+        if isinstance(newline,str) and isinstance(buf,bytes):
+            newline=Latin1_encode(newline)
         return self.send(buf+newline)
 
     def recv(self,n,timeout=None):


### PR DESCRIPTION
example case where the bug can be replicated
```py
from winpwn import *
from os.path import normpath
import pwn

exe = normpath('./challenge.exe')
io = process(exe)
payload = pwn.p64(0x010101)
io.send(payload)
```

First occurred error in `win.py`
```
Traceback (most recent call last):
  File "D:\REDACTED\test.py", line 8, in <module>
    io.send(payload)
  File "C:\Python311\Lib\site-packages\winpwn\winpwn.py", line 33, in send
    rs=self.write(buf)
       ^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\winpwn\winpwn.py", line 199, in write
    return self.Process.write(buf)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\winpwn\win.py", line 234, in write
    return self.pipe.write(buf)
           ^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\winpwn\win.py", line 157, in write
    buf=Latin1_encode(buf)
        ^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\winpwn\misc.py", line 84, in Latin1_encode
    return bytes(string,"Latin1")
           ^^^^^^^^^^^^^^^^^^^^^^
TypeError: encoding without a string argument
```

Second occurred error in `misc.py`
```
Traceback (most recent call last):
  File "D:\REDACTED\test.py", line 8, in <module>
    io.send(payload)
  File "C:\Python311\Lib\site-packages\winpwn\winpwn.py", line 34, in send
    showbuf(buf)
  File "C:\Python311\Lib\site-packages\winpwn\misc.py", line 140, in showbuf
    if buf.endswith(context.newline):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: endswith first arg must be bytes or a tuple of bytes, not str
```

Third occurred error in cases when communicating through remote socket as follows
```py
from winpwn import *
from os.path import normpath
import pwn

io = remote('127.0.0.1', 9001)
payload = pwn.p64(0x010101)
io.send(payload)
```

and it would generate the following error
```
Traceback (most recent call last):
  File "D:\REDACTED\test.py", line 9, in <module>
    io.send(payload)
  File "C:\Python311\Lib\site-packages\winpwn\winpwn.py", line 33, in send
    rs=self.write(buf)
       ^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\winpwn\winpwn.py", line 157, in write
    return self.sock.send(Latin1_encode(buf))
                          ^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\winpwn\misc.py", line 84, in Latin1_encode
    return bytes(string,"Latin1")
           ^^^^^^^^^^^^^^^^^^^^^^
TypeError: encoding without a string argument
```


