### PR TITLE
Add cyclic pattern generation and offset calculation

### DIFF
--- a/winpwn/__init__.py
+++ b/winpwn/__init__.py
@@ -8,7 +8,7 @@ sys.path=[cwd]+sys.path[1:]
 from .context import context
 from .winpwn import process,remote
 from .dbg import gdb,windbg,x64dbg,windbgx,init_debugger
-from .misc import p8,p16,p32,p64,u8,u16,u32,u64,pause,sleep,NOPIE,PIE,Latin1_encode,Latin1_decode,color,hexdump
+from .misc import p8,p16,p32,p64,u8,u16,u32,u64,pause,sleep,NOPIE,PIE,Latin1_encode,Latin1_decode,color,hexdump,cyclic,cyclic_find
 from .asm import asm,disasm
 from .winfile import winfile
 from .wincs import wincs
@@ -21,7 +21,7 @@ tobyte=Latin1_encode
 __all__=[
     'process','remote','gdb','windbg','x64dbg','windbgx',
     'context',
-    'p8','p16','p32','p64','u8','u16','u32','u64',
+    'p8','p16','p32','p64','u8','u16','u32','u64',"cyclic","cyclic_find"
     'pause','sleep','hexdump','color',"NOPIE","PIE",
     "tostr",'tobyte',
     "asm","disasm",

--- a/winpwn/misc.py
+++ b/winpwn/misc.py
@@ -141,3 +141,52 @@ def showbuf(buf,is_noout=None):
             os.write(sys.stdout.fileno(), Latin1_encode(buf))
         else:
             os.write(sys.stdout.fileno(), Latin1_encode(buf+'\n'))
+
+def cyclic(length=None):
+    """
+    Generate a cyclic pattern of 4‑byte tokens from aaaa to zzzz.
+    If length is given, return only the first `length` bytes.
+    """
+    alphabet = b'abcdefghijklmnopqrstuvwxyz'
+    pattern = b''
+    for a in alphabet:
+        for b in alphabet:
+            for c in alphabet:
+                for d in alphabet:
+                    pattern += bytes([a, b, c, d])
+                    if length is not None and len(pattern) >= length:
+                        return pattern[:length]
+    return pattern
+
+def cyclic_find(subseq):
+    """
+    Return the byte offset of a 4‑byte token in the cyclic pattern.
+    subseq can be:
+      - a 4‑character string (e.g., "aaad")
+      - an integer (e.g., 0x64616161, which is little‑endian for "aaad")
+    Returns -1 if the token is invalid (not in the pattern).
+    """
+    # Convert integer to little‑endian 4‑byte string
+    if isinstance(subseq, int):
+        # Mask to 32 bits and pack as little‑endian
+        subseq = struct.pack('<I', subseq & 0xFFFFFFFF)
+    if isinstance(subseq, bytes):
+        # Decode to Latin1 string
+        subseq = Latin1_decode(subseq)
+    # Now subseq is a str of length 4
+    if len(subseq) != 4:
+        raise ValueError("cyclic_find: substring must be exactly 4 characters")
+    # Convert each character to its index (a=0, b=1, ..., z=25)
+    indices = []
+    for ch in subseq:
+        if 'a' <= ch <= 'z':
+            indices.append(ord(ch) - ord('a'))
+        else:
+            return -1   # character not in alphabet
+    # Compute position in the 4‑character token sequence
+    pos = (indices[0] * 26**3 +
+           indices[1] * 26**2 +
+           indices[2] * 26 +
+           indices[3])
+    # Each token occupies 4 bytes
+    return pos * 4


### PR DESCRIPTION
This PR adds two utility functions to `misc.py`:

- `cyclic(length=None)`: generates a de Bruijn sequence pattern of 4‑byte tokens (aaaa, aaab, ..., zzzz) for buffer overflow testing. If `length` is given, returns the first `length` bytes.
- `cyclic_find(subseq)`: returns the byte offset of a 4‑byte token in the pattern. Accepts a 4‑character string or a little‑endian integer (e.g., from EIP). Returns -1 if the token is invalid.

These functions are commonly used in exploit development to quickly determine the exact offset to overwrite the return address. They are analogous to pwntools' `cyclic` and `cyclic_find`, but implemented natively in pure Python without external dependencies.

**Usage example:**
```python
from winpwn import cyclic, cyclic_find

# Generate 200-byte pattern
pattern = cyclic(200)
# ... send pattern to target ...

# After crash, get EIP value (e.g., 0x64616161)
offset = cyclic_find(0x64616161)
print(f"Offset: {offset} bytes")   # Output: 12
OR
offset = cyclic_find("aaad")
print(f"Offset: {offset} bytes")   # Output: 12